### PR TITLE
Remove manual renaming of gemset from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,6 @@ It includes quite a lot of best practices over the years and tailored for our AW
 git clone git@github.com:alex-zige/rails_on_rails.git
 
 ```
-##Config gemset
-
-Modify ``.ruby-gemset`` change ``rails_on_rails`` to your project
-
-```
-your-project-name
-
-```
 
 ##Config database
 ```


### PR DESCRIPTION
Don't need to do this. Rename gem will do it for you later. In fact, if you do this, rename gem will not work

```
rails g rename:app_to nab-property-hunter
Invalid application name nab-property-hunter, already in use. Please choose another application name.
```
