### PR TITLE
Use plural items for array type

### DIFF
--- a/spec/support/json_schema/api/v1/user_schema.rb
+++ b/spec/support/json_schema/api/v1/user_schema.rb
@@ -46,7 +46,7 @@ module JsonSchema
      def self.simple_users
         {
           type: :array,
-          item: simple_user
+          items: simple_user
         }
       end
     end


### PR DESCRIPTION
correct typos. 
